### PR TITLE
ZENODO variable doesn't exist in the code, but zenReq does. Fixed.

### DIFF
--- a/R/ZenodoManager.R
+++ b/R/ZenodoManager.R
@@ -732,7 +732,7 @@ ZenodoManager <-  R6Class("ZenodoManager",
       if(zenReq$getStatus() %in% c(200,201)){
         out <- zenReq$getResponse()
         out_id <- unlist(strsplit(out$links$latest_draft,"depositions/"))[[2]]
-        out <-  ZENODO$getDepositionById(out_id)
+        out <-  zenReq$getDepositionById(out_id)
         self$INFO(sprintf("Successful new version record created for concept DOI '%s'", record$getConceptDOI()))
         record$id <- out$id
         record$metadata$doi <- NULL


### PR DESCRIPTION
I kept encountering an error about not finding the object "ZENODO". Looked into it and it was because the code uses ZENODO, but should actually be zenReq.