### PR TITLE
fix getDepositionByConceptDOI method

### DIFF
--- a/R/ZenodoManager.R
+++ b/R/ZenodoManager.R
@@ -594,11 +594,12 @@ ZenodoManager <-  R6Class("ZenodoManager",
       query <- sprintf("conceptdoi:%s", gsub("/", "//", conceptdoi))
       result <- self$getDepositions(q = query, exact = TRUE)
       if(length(result)>0){
-        result <- result[[1]]
-        if(result$conceptdoi == conceptdoi){
-          self$INFO(sprintf("Successfully fetched record for concept DOI '%s'!", conceptdoi))
-        }else{
+        dois <- vapply(result, function(i) i$doi, character(1))
+        if (!conceptdoi %in% dois){
           result <- NULL
+        }else{
+          result <- result[[which(dois == conceptdoi)[1]]]
+          self$INFO(sprintf("Successfully fetched record for concept DOI '%s'!", conceptdoi))
         }
       }else{
         result <- NULL


### PR DESCRIPTION
@eblondel The current code has the following lines:

https://github.com/eblondel/zen4R/blob/969053ac9d12b21cc32898dbe3ee0fbfe0bdc475/R/ZenodoManager.R#L593-L597

which presumes that the requested `conceptdoi` is the first element of the returned result, yet this is not necessarily so. In particular, personal releases associated with a token are delivered in chronological order. This PR rectifies by matching `conceptdoi` values of all returned results to find the desired one.