### PR TITLE
fix #84

### DIFF
--- a/R/ZenodoRequest.R
+++ b/R/ZenodoRequest.R
@@ -57,8 +57,14 @@ ZenodoRequest <- R6Class("ZenodoRequest",
     GET = function(url, request){
       req <- paste(url, request, sep="/")
       self$INFO(sprintf("Fetching %s", req))
-      headers <- c("Authorization" = paste("Bearer",private$token))
-      
+      headers <- c(
+        "Authorization" = paste("Bearer",private$token),
+        "User-Agent" = paste(
+          "Mozilla/5.0 (X11; Linux x86_64)",
+          "AppleWebKit/537.36 (KHTML, like Gecko)",
+          "Chrome/103.0.0.0 Safari/537.36"
+        )
+      )
       r <- NULL
       if(self$verbose.debug){
         r <- with_verbose(GET(req, add_headers(headers)))


### PR DESCRIPTION
This PR fixes issue #84 (on my system, at least). To achieve this, the PR adds a User-Agent header to making making GET requests to the Zenodo API (apologies if I'm getting the terminology wrong). I stumbled upon this fix by comparing the HTTP headers used to acess the API in my web browser (Google Chrome) which worked correctly with those used in the zen4R package. Please let me know if you there's any further changes needed to merge this PR or additional tests you would like me to run?