### PR TITLE
some ZenodoRecord functions gain a zen argument

### DIFF
--- a/R/ZenodoRecord.R
+++ b/R/ZenodoRecord.R
@@ -429,8 +429,8 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
     #'    recognized by Zenodo, the function will return an error. The list of licenses can
     #'    fetched with the \code{ZenodoManager} and the function \code{$getLicenses()}.
     #' @param licenseId a license Id 
-    setLicense = function(licenseId){
-      zen <- ZenodoManager$new()
+    #' @param zen A ZenodoManager object
+    setLicense = function(licenseId, zen = ZenodoManager$new()){
       zen_license <- zen$getLicenseById(licenseId)
       if(!is.null(zen_license$status)){
         errorMsg <- sprintf("License with id '%s' doesn't exist in Zenodo", licenseId)
@@ -662,10 +662,10 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
     #' @param community community to add. The community should be set with the Zenodo id of the community. 
     #'   If not recognized by Zenodo, the function will return an error. The list of communities can fetched 
     #'   with the \code{ZenodoManager} and the function \code{$getCommunities()}.
+    #' @param zen A ZenodoManager object
     #' @return \code{TRUE} if added, \code{FALSE} otherwise
-    addCommunity = function(community){
+    addCommunity = function(community, zen = ZenodoManager$new()){
       added <- FALSE
-      zen <- ZenodoManager$new()
       if(is.null(self$metadata$communities)) self$metadata$communities <- list()
       if(!(community %in% sapply(self$metadata$communities, function(x){x$identifier}))){
         zen_community <- zen$getCommunityById(community)
@@ -713,10 +713,10 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
     #' @param grant grant to add. The grant should be set with the id of the grant. If not
     #'    recognized by Zenodo, the function will return an warning only. The list of grants can
     #'    fetched with the \code{ZenodoManager} and the function \code{$getGrants()}.
+    #' @param zen A ZenodoManager object
     #' @return \code{TRUE} if added, \code{FALSE} otherwise
-    addGrant = function(grant){
+    addGrant = function(grant, zen = ZenodoManager$new()){
       added <- FALSE
-      zen <- ZenodoManager$new()
       if(is.null(self$metadata$grants)) self$metadata$grants <- list()
       if(!(grant %in% self$metadata$grants)){
         if(regexpr("::", grant)>0){

--- a/man/ZenodoRecord.Rd
+++ b/man/ZenodoRecord.Rd
@@ -745,13 +745,15 @@ Set license. The license should be set with the Zenodo id of the license. If not
    recognized by Zenodo, the function will return an error. The list of licenses can
    fetched with the \code{ZenodoManager} and the function \code{$getLicenses()}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$setLicense(licenseId)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$setLicense(licenseId, zen = ZenodoManager$new())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{licenseId}}{a license Id}
+
+\item{\code{zen}}{A ZenodoManager object}
 }
 \if{html}{\out{</div>}}
 }
@@ -1077,7 +1079,7 @@ the Zenodo id of the community. If not recognized by Zenodo, the function will r
 \subsection{Method \code{addCommunity()}}{
 Adds a community to the record metadata.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$addCommunity(community)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$addCommunity(community, zen = ZenodoManager$new())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1086,6 +1088,8 @@ Adds a community to the record metadata.
 \item{\code{community}}{community to add. The community should be set with the Zenodo id of the community. 
 If not recognized by Zenodo, the function will return an error. The list of communities can fetched 
 with the \code{ZenodoManager} and the function \code{$getCommunities()}.}
+
+\item{\code{zen}}{A ZenodoManager object}
 }
 \if{html}{\out{</div>}}
 }
@@ -1138,7 +1142,7 @@ the Zenodo id of the grant If not recognized by Zenodo, the function will raise 
 \subsection{Method \code{addGrant()}}{
 Adds a grant to the record metadata.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$addGrant(grant)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ZenodoRecord$addGrant(grant, zen = ZenodoManager$new())}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1147,6 +1151,8 @@ Adds a grant to the record metadata.
 \item{\code{grant}}{grant to add. The grant should be set with the id of the grant. If not
 recognized by Zenodo, the function will return an warning only. The list of grants can
 fetched with the \code{ZenodoManager} and the function \code{$getGrants()}.}
+
+\item{\code{zen}}{A ZenodoManager object}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
I'm creating a unit test for my [upload_zenodo()](https://github.com/inbo/checklist/blob/0.3.1/R/upload_zenodo.R) function using https://sandbox.zenodo.org. However some methods of `ZenodoRec` require access to https://zenodo.org. I don't want to give my unit test functions access to https://zenodo.org.

This PR allows to pass a `ZenodoManager` object. The default behaviour is unchanged (use the default `ZenodoManager` pointing to https://zenodo.org).