### PR TITLE
Remove trailing information from record_id.

### DIFF
--- a/R/ZenodoManager.R
+++ b/R/ZenodoManager.R
@@ -700,7 +700,8 @@ ZenodoManager <-  R6Class("ZenodoManager",
       
       #id of the last record
       record_id <- unlist(strsplit(record$links$latest,"records/"))[[2]] 
-      
+      # strip trailing info from record_id
+      record_id <- gsub("(.*?)/(.*)", "\\1", record_id)
       self$INFO(sprintf("Creating new version for record '%s' (concept DOI: '%s')", record_id, record$getConceptDOI()))
       request <- sprintf("deposit/depositions/%s/actions/newversion", record_id)
       zenReq <- ZenodoRequest$new(private$url, type, request, data = NULL,


### PR DESCRIPTION
Transforms `12345678/versions/latest` into `12345678`. Using `12345678/versions/latest` as record_id returns in an invalid request url.