### PR TITLE
A few minor fixes

### DIFF
--- a/R/ZenodoRecord.R
+++ b/R/ZenodoRecord.R
@@ -909,7 +909,7 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
     #' @description Set subjects
     #' @param subjects a vector or list of subjects to set for the record
     setSubjects = function(subjects){
-      if(is.null(self$metadata$subjects)) self$metadata$subjects <- list()
+      self$metadata$subjects <- list()
       for(subject in subjects){
         self$addSubject(subject)
       }

--- a/R/ZenodoRecord.R
+++ b/R/ZenodoRecord.R
@@ -821,7 +821,7 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
         )
         if(!is.null(resource_type)) {
           zenodo = ZenodoManager$new()
-          res = ZENODO$getResourceTypeById(resource_type)
+          res = zenodo$getResourceTypeById(resource_type)
           if(!is.null(res)){
             new_rel$resource_type = list(id = resource_type)
           }

--- a/zen4R.Rproj
+++ b/zen4R.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d92a0b8d-3a34-4931-9b4b-d592676d6104
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
1. `ExportAs` is running for a zenodo draft and returned an html page. Suggesting a fix for checking for `is_draft()`Note that it actually works on the browser with "? preview=1" but requires authentification. 
2. Seems like there was a typo with uppercase `ZENODO` vs `zenodo`.
3. `setSubjects` is actually adding subjects rather than starting from an empty list. Suggesting a fix for this. 