### PR TITLE
Resolve spaces in url

### DIFF
--- a/R/ZenodoRecord.R
+++ b/R/ZenodoRecord.R
@@ -1512,7 +1512,9 @@ ZenodoRecord <-  R6Class("ZenodoRecord",
           target_file <-file.path(path, file$filename)
           #check md5sum
           target_file_md5sum <- tools::md5sum(target_file)
-          if(target_file_md5sum==file$checksum){
+          # need unname() as it is a named vector, we just want the md5sum
+          md5sum_match <- identical(unname(target_file_md5sum), file$checksum)
+          if(md5sum_match){
             if (!quiet){
               infoMsg = sprintf("File '%s': integrity verified (md5sum: %s)\n",
                                 file$filename, file$checksum)


### PR DESCRIPTION
Resolves #183 

This PR helps sanitize the URL using `tools::URLencode()` in `download.files()`, and also uses a check on the md5sum that will result in TRUE/FALSE if they do not match, in case one side of `==` is NA.

New behaviour:

``` r
library(zen4R)

dl_url <- "https://doi.org/10.5281/zenodo.3878754"
td <- tempdir()
list.files(td)
#> character(0)
file_downloaded <- download_zenodo(doi = dl_url, path = td)
#> ✔ Successfully fetched list of published records!
#> ! No record for DOI 'https://doi.org/10.5281/zenodo.3878754'!
#> ℹ Try to get deposition by Zenodo specific record id '3878754'
#> ℹ Successfully fetched list of published records - page 1
#> ✔ Successfully fetched list of published records!
#> ✔ Successfully fetched record for id '3878754'!
#> ℹ Download in sequential mode
#> [zen4R][INFO] ZenodoRecord - Download in sequential mode
#> ℹ Will download 8 files from record '3878754' (doi: '10.5281/zenodo.3878754') - total size: 892.1 KiB
#> [zen4R][INFO] ZenodoRecord - Will download 8 files from record '3878754' (doi: '10.5281/zenodo.3878754') - total size: 892.1 KiB
#> ℹ Downloading file '2019_Zhang_China_dictionary.xls' - size: 66 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_dictionary.xls' - size: 66 KiB
#> ℹ Downloading file '2019_Zhang_China_hh_common.csv' - size: 18.9 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_hh_common.csv' - size: 18.9 KiB
#> ℹ Downloading file '2019_Zhang_China_participant_common.csv' - size: 26.3 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_participant_common.csv' - size: 26.3 KiB
#> ℹ Downloading file '2019_Zhang_China_sday.csv' - size: 28.2 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_sday.csv' - size: 28.2 KiB
#> ℹ Downloading file 'China dataset_5June2020.rar' - size: 77.5 KiB
#> [zen4R][INFO] Downloading file 'China dataset_5June2020.rar' - size: 77.5 KiB
#> ℹ Downloading file '2019_Zhang_China_contact_common.csv' - size: 478.6 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_contact_common.csv' - size: 478.6 KiB
#> ℹ Downloading file '2019_Zhang_China_participant_extra.csv' - size: 28.7 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_participant_extra.csv' - size: 28.7 KiB
#> ℹ Downloading file '2019_Zhang_China_contact_extra.csv' - size: 167.9 KiB
#> [zen4R][INFO] Downloading file '2019_Zhang_China_contact_extra.csv' - size: 167.9 KiB
#> ℹ Files downloaded at '/private/var/folders/cz/hrp33k3s0jlcb_gg9snlqh580000gq/T/Rtmpx8acpk'.
#> [zen4R][INFO] Files downloaded at '/private/var/folders/cz/hrp33k3s0jlcb_gg9snlqh580000gq/T/Rtmpx8acpk'.
#> ℹ Verifying file integrity...
#> [zen4R][INFO] ZenodoRecord - Verifying file integrity...
#> ℹ File '2019_Zhang_China_dictionary.xls': integrity verified (md5sum: 709c0f0524d528bd78d48e9d1d1c2ee0)
#> [zen4R][INFO] File '2019_Zhang_China_dictionary.xls': integrity verified (md5sum: 709c0f0524d528bd78d48e9d1d1c2ee0)
#> ℹ File '2019_Zhang_China_hh_common.csv': integrity verified (md5sum: 723d5bac9c0a6974f39b54aa5e323579)
#> [zen4R][INFO] File '2019_Zhang_China_hh_common.csv': integrity verified (md5sum: 723d5bac9c0a6974f39b54aa5e323579)
#> ℹ File '2019_Zhang_China_participant_common.csv': integrity verified (md5sum: 228c345f1b5ea85cdaaf62e0d43cb1ea)
#> [zen4R][INFO] File '2019_Zhang_China_participant_common.csv': integrity verified (md5sum: 228c345f1b5ea85cdaaf62e0d43cb1ea)
#> ℹ File '2019_Zhang_China_sday.csv': integrity verified (md5sum: a9d2d16e47bd514449d365f5b3f01854)
#> [zen4R][INFO] File '2019_Zhang_China_sday.csv': integrity verified (md5sum: a9d2d16e47bd514449d365f5b3f01854)
#> ℹ File 'China dataset_5June2020.rar': integrity verified (md5sum: 60558e77c2b2168bb054725aeef5c072)
#> [zen4R][INFO] File 'China dataset_5June2020.rar': integrity verified (md5sum: 60558e77c2b2168bb054725aeef5c072)
#> ℹ File '2019_Zhang_China_contact_common.csv': integrity verified (md5sum: fff2b698d333eb5b046720a034a44392)
#> [zen4R][INFO] File '2019_Zhang_China_contact_common.csv': integrity verified (md5sum: fff2b698d333eb5b046720a034a44392)
#> ℹ File '2019_Zhang_China_participant_extra.csv': integrity verified (md5sum: b5a71aec6fcfa0a8a92774962dd734dc)
#> [zen4R][INFO] File '2019_Zhang_China_participant_extra.csv': integrity verified (md5sum: b5a71aec6fcfa0a8a92774962dd734dc)
#> ℹ File '2019_Zhang_China_contact_extra.csv': integrity verified (md5sum: 5dcc4d8edc90b95241452bf9ff121418)
#> [zen4R][INFO] File '2019_Zhang_China_contact_extra.csv': integrity verified (md5sum: 5dcc4d8edc90b95241452bf9ff121418)
#> ✔ End of download
#> [zen4R][INFO] ZenodoRecord - End of download
```

<sup>Created on 2025-08-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.1 (2025-06-13)
#>  os       macOS Sonoma 14.5
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Australia/Hobart
#>  date     2025-08-12
#>  pandoc   3.4 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.7.31 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version   date (UTC) lib source
#>  cli           3.6.5     2025-04-23 [1] CRAN (R 4.5.0)
#>  curl          6.4.0     2025-06-22 [1] CRAN (R 4.5.0)
#>  digest        0.6.37    2024-08-19 [1] CRAN (R 4.5.0)
#>  evaluate      1.0.4     2025-06-18 [1] CRAN (R 4.5.0)
#>  fastmap       1.2.0     2024-05-15 [1] CRAN (R 4.5.0)
#>  fs            1.6.6     2025-04-12 [1] CRAN (R 4.5.0)
#>  glue          1.8.0     2024-09-30 [1] CRAN (R 4.5.0)
#>  htmltools     0.5.8.1   2024-04-04 [1] CRAN (R 4.5.0)
#>  httr          1.4.7     2023-08-15 [1] CRAN (R 4.5.0)
#>  jsonlite      2.0.0     2025-03-27 [1] CRAN (R 4.5.0)
#>  keyring       1.4.1     2025-06-15 [1] CRAN (R 4.5.0)
#>  knitr         1.50      2025-03-16 [1] CRAN (R 4.5.0)
#>  lifecycle     1.0.4     2023-11-07 [1] CRAN (R 4.5.0)
#>  plyr          1.8.9     2023-10-02 [1] CRAN (R 4.5.0)
#>  R6            2.6.1     2025-02-15 [1] CRAN (R 4.5.0)
#>  Rcpp          1.1.0     2025-07-02 [1] CRAN (R 4.5.0)
#>  reprex        2.1.1     2024-07-06 [1] CRAN (R 4.5.0)
#>  rlang         1.1.6     2025-04-11 [1] CRAN (R 4.5.0)
#>  rmarkdown     2.29      2024-11-04 [1] CRAN (R 4.5.0)
#>  rstudioapi    0.17.1    2024-10-22 [1] CRAN (R 4.5.0)
#>  sessioninfo   1.2.3     2025-02-05 [1] CRAN (R 4.5.0)
#>  utf8          1.2.6     2025-06-08 [1] CRAN (R 4.5.0)
#>  withr         3.0.2     2024-10-28 [1] CRAN (R 4.5.0)
#>  xfun          0.52      2025-04-02 [1] CRAN (R 4.5.0)
#>  XML           3.99-0.18 2025-01-01 [1] CRAN (R 4.5.0)
#>  xml2          1.3.8     2025-03-14 [1] CRAN (R 4.5.0)
#>  yaml          2.3.10    2024-07-26 [1] CRAN (R 4.5.0)
#>  zen4R       * 0.10.3    2025-08-12 [1] local
#> 
#>  [1] /Users/nick_1/Library/R/arm64/4.5/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>