### PR TITLE
fix typo that breaks get_citation() in some instances

### DIFF
--- a/R/ZenodoManager.R
+++ b/R/ZenodoManager.R
@@ -1767,7 +1767,7 @@ ZenodoManager <-  R6Class("ZenodoManager",
       out <- zenReq$getResponse()
       if(zenReq$getStatus() == 200){
         infoMsg = sprintf("Successful fetched file metadata for record '%s' - filename '%s'", recordId, filename)
-        cli::cli_alert_success(infoMSg)
+        cli::cli_alert_success(infoMsg)
         self$INFO(infoMsg)
       }else{
         errMsg = sprintf("Error while fetching file(s) for record '%s': %s", recordId, out$message)
@@ -2139,7 +2139,7 @@ ZenodoManager <-  R6Class("ZenodoManager",
       if(length(result)>0){
         result <- result[[1]]
         if(result$getConceptId() == conceptrecid){
-          infoMSg = sprintf("Successfully fetched record for concept id '%s'!",conceptrecid)
+          infoMsg = sprintf("Successfully fetched record for concept id '%s'!",conceptrecid)
           cli::cli_alert_success(infoMsg)
           self$INFO(infoMsg)
         }else{


### PR DESCRIPTION
resolves #191

Working behaviour:

``` r
library(zen4R)

peru_doi <- "https://doi.org/10.5281/zenodo.1095664"
get_citation(peru_doi, style = "bibtex")
#> ✔ Successfully fetched list of published records!
#> ! No record for DOI 'https://doi.org/10.5281/zenodo.1095664'!
#> ℹ Try to get deposition by Zenodo specific record id '1095664'
#> ✔ Successfully fetched list of published records!
#> ! No record for id '1095664'!
#> ✔ Successfully fetched list of published records!
#> ! No published record for concept DOI 'https://doi.org/10.5281/zenodo.1095664'!
#> ℹ Try to get published record by Zenodo concept record id '1095664'
#> ℹ Successfully fetched list of published records - page 1
#> ✔ Successfully fetched list of published records!
#> ✔ Successfully fetched record for concept id '1095664'!
#> ℹ Successfully fetched list of published records - page 1
#> ✔ Successfully fetched list of published records!
#> ℹ Successfully fetched list of published records - page 1
#> ✔ Successfully fetched list of published records!
#> ✔ Successfully fetched record for DOI '10.5281/zenodo.3874805'!
#> No encoding supplied: defaulting to UTF-8.
#> [1] "@dataset{carlos_g_grijalva_2020_3874805,\n  author       = {Carlos G. Grijalva and\n                  Nele Goeyvaerts and\n                  Hector Verastegui and\n                  Kathryn M. Edwards and\n                  Ana I. Gil and\n                  Claudio F. Lanata and\n                  Niel Hens},\n  title        = {Social contact data for Peru},\n  month        = jun,\n  year         = 2020,\n  publisher    = {Zenodo},\n  version      = 2,\n  doi          = {10.5281/zenodo.3874805},\n  url          = {https://doi.org/10.5281/zenodo.3874805},\n}"
```

<sup>Created on 2025-08-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">

<summary>

Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.5.1 (2025-06-13)
#>  os       macOS Sequoia 15.6
#>  system   aarch64, darwin20
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       Australia/Hobart
#>  date     2025-08-18
#>  pandoc   3.4 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/aarch64/ (via rmarkdown)
#>  quarto   1.7.31 @ /usr/local/bin/quarto
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version   date (UTC) lib source
#>  cli           3.6.5     2025-04-23 [1] CRAN (R 4.5.0)
#>  curl          6.4.0     2025-06-22 [1] CRAN (R 4.5.0)
#>  digest        0.6.37    2024-08-19 [1] CRAN (R 4.5.0)
#>  evaluate      1.0.4     2025-06-18 [1] CRAN (R 4.5.0)
#>  fastmap       1.2.0     2024-05-15 [1] CRAN (R 4.5.0)
#>  fs            1.6.6     2025-04-12 [1] CRAN (R 4.5.0)
#>  glue          1.8.0     2024-09-30 [1] CRAN (R 4.5.0)
#>  htmltools     0.5.8.1   2024-04-04 [1] CRAN (R 4.5.0)
#>  httr          1.4.7     2023-08-15 [1] CRAN (R 4.5.0)
#>  jsonlite      2.0.0     2025-03-27 [1] CRAN (R 4.5.0)
#>  keyring       1.4.1     2025-06-15 [1] CRAN (R 4.5.0)
#>  knitr         1.50      2025-03-16 [1] CRAN (R 4.5.0)
#>  lifecycle     1.0.4     2023-11-07 [1] CRAN (R 4.5.0)
#>  plyr          1.8.9     2023-10-02 [1] CRAN (R 4.5.0)
#>  R6            2.6.1     2025-02-15 [1] CRAN (R 4.5.0)
#>  Rcpp          1.1.0     2025-07-02 [1] CRAN (R 4.5.0)
#>  reprex        2.1.1     2024-07-06 [1] CRAN (R 4.5.0)
#>  rlang         1.1.6     2025-04-11 [1] CRAN (R 4.5.0)
#>  rmarkdown     2.29      2024-11-04 [1] CRAN (R 4.5.0)
#>  rstudioapi    0.17.1    2024-10-22 [1] CRAN (R 4.5.0)
#>  sessioninfo   1.2.3     2025-02-05 [1] CRAN (R 4.5.0)
#>  utf8          1.2.6     2025-06-08 [1] CRAN (R 4.5.0)
#>  withr         3.0.2     2024-10-28 [1] CRAN (R 4.5.0)
#>  xfun          0.52      2025-04-02 [1] CRAN (R 4.5.0)
#>  XML           3.99-0.18 2025-01-01 [1] CRAN (R 4.5.0)
#>  xml2          1.3.8     2025-03-14 [1] CRAN (R 4.5.0)
#>  yaml          2.3.10    2024-07-26 [1] CRAN (R 4.5.0)
#>  zen4R       * 0.10.3    2025-08-18 [1] local
#> 
#>  [1] /Users/nick_1/Library/R/arm64/4.5/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.5-arm64/Resources/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>